### PR TITLE
Improve syntax highlighting of inline assembler

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -77,13 +77,13 @@ export function registerBbcBasicLanguage() {
             remStatement: [[/.*/, 'comment', '@pop']],
             asm: [
                 // Not exactly working properly yet...but a start
-                [/[a-zA-Z]{3}/, 'keyword'],
+                [/EQU[BDSW]|[A-Z]{3}/, 'keyword'],
                 [/[ \t\r\n]+/, 'white'],
-                [/[;\\].*/, 'comment'],
-                {include: '@common'},
+                [/[;\\][^:]*/, 'comment'],
                 [/,\s*[XY]/, 'keyword'],
                 // labels
-                [/\.[a-zA-Z_$][\w$]*/, 'type.identifier'],
+                [/\.([a-zA-Z_][\w]*%?|@%)/, 'type.identifier'],
+                {include: '@common'},
                 [']', {token: 'delimiter.square', next: '@pop'}]
             ]
         }


### PR DESCRIPTION
* Assembler instructions need to be upper case
* Recognise EQUB, etc
* Move @common lower to unhide rules to highlight indexing and labels
* Comments end at a `:`
* Labels can't contain $, but can end in a %
* Special case @% as a valid label

See #33