### PR TITLE
Allow FN in expressions

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -6,9 +6,9 @@ function escape(token) {
 }
 
 function isExpressionToken(keyword) {
-    // Does this token look like it'd be useful as a token. Used to find sensible things to tokenise
+    // Does this token look like it'd be useful in an expression. Used to find sensible things to tokenise
     // in assembly statements (like LEN).
-    return (keyword.flags & ~Flags.Conditional) === 0;
+    return (keyword.flags & ~Flags.Conditional) === 0 || keyword.keyword === 'FN';
 }
 
 const conditionalTokens = new Set(

--- a/test/bbcbasic_test.js
+++ b/test/bbcbasic_test.js
@@ -188,6 +188,15 @@ describe("Tokenisation", () => {
                 {offset: 8, type: "variable"},
             ]
         );
+        checkTokens(
+            ["[", "EQUSFNx"],
+            [{offset: 0, type: "delimiter.square"}],
+            [
+                {offset: 0, type: "keyword.directive"},
+                {offset: 4, type: "keyword"},
+                {offset: 6, type: "variable"},
+            ]
+        );
     });
     it("should notice REM statements", () => {
         checkTokens(


### PR DESCRIPTION
"FN" is OK in an expression, but has the "F" flag set.  "PROC" also
has the "F" flag but isn't OK in an expression, so just allow "FN"
as a special case rather than excluding the "F" flag from the check.