### PR TITLE
Improve detokenisation

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -114,7 +114,7 @@ class StringHandler {
     }
 
     onSpace() {
-        this.output += ' ';
+        this.output += " ";
     }
 
     onToken(token) {
@@ -138,11 +138,13 @@ function detokeniseInternal(text, handler) {
             leaveRestOfLine = false;
         }
         if (afterConditionalToken) {
-            if ((charCode >= Chars.FirstToken) ||
-                (ch >= 'A' && ch <= 'Z') ||
-                (ch >= 'a' && ch <= 'z') ||
-                (ch >= '0' && ch <= '9') ||
-                (ch === '_')) {
+            if (
+                charCode >= Chars.FirstToken ||
+                (ch >= "A" && ch <= "Z") ||
+                (ch >= "a" && ch <= "z") ||
+                (ch >= "0" && ch <= "9") ||
+                ch === "_"
+            ) {
                 handler.onSpace();
             }
             afterConditionalToken = false;
@@ -195,10 +197,11 @@ function detokeniseInternal(text, handler) {
             handler.onCharCode(charCode);
         } else {
             handler.onCharacter(ch);
-            inIdentifier = (ch >= 'A' && ch <= 'Z') ||
-                (ch >= 'a' && ch <= 'z') ||
-                (ch == '_') ||
-                (inIdentifier && ch >= '0' && ch <= '9');
+            inIdentifier =
+                (ch >= "A" && ch <= "Z") ||
+                (ch >= "a" && ch <= "z") ||
+                ch == "_" ||
+                (inIdentifier && ch >= "0" && ch <= "9");
         }
     }
 }
@@ -237,8 +240,7 @@ class PartialHandler extends StringHandler {
         super();
     }
 
-    onSpace() {
-    }
+    onSpace() {}
 
     onToken(token) {
         this.onCharCode(token);

--- a/test/tokens_test.js
+++ b/test/tokens_test.js
@@ -49,13 +49,13 @@ VDUQ?I:NEXT:Y=Y+(5ORY>1):Q=Q+L+1:P=0:NEXT:VDU1
         );
     });
     it("should add spaces after tokens with the Conditional flag", () => {
-        assert.strictEqual(detokenise('\xf1\x9f\x841'), 'PRINTERR OR1');
+        assert.strictEqual(detokenise("\xf1\x9f\x841"), "PRINTERR OR1");
     });
     it("should add spaces before tokens which follow an identifier", () => {
-        assert.strictEqual(detokenise('\xf1X\x84Y'), 'PRINTX ORY');
+        assert.strictEqual(detokenise("\xf1X\x84Y"), "PRINTX ORY");
     });
     it("shouldn't expand tokens after DATA", () => {
-        assert.strictEqual(detokenise('\xDCX\x84Y'), 'DATAX\u0184Y');
+        assert.strictEqual(detokenise("\xDCX\x84Y"), "DATAX\u0184Y");
     });
 });
 
@@ -107,8 +107,7 @@ describe("Partial detokenisation", () => {
         assert.strictEqual(partialDetokenise(rawProgram), '10 \xf1 "Hello world"\n11 \xe5 10');
     });
     it("should not result in invisible Unicode characters", () => {
-        const rawProgram =
-            '\x0d\x00\x0a\x08\xf1\x9f\x841\x0d\xff';
-        assert.strictEqual(partialDetokenise(rawProgram), '\xf1\u019f\u01841');
+        const rawProgram = "\x0d\x00\x0a\x08\xf1\x9f\x841\x0d\xff";
+        assert.strictEqual(partialDetokenise(rawProgram), "\xf1\u019f\u01841");
     });
 });

--- a/test/tokens_test.js
+++ b/test/tokens_test.js
@@ -41,12 +41,21 @@ Q=+5:ãJ=0¸16:X=?Q-19:L=Q?1-96:Q=Q+2:ãI=0¸L:æ0,P:ì10*X+64*I,60*Y:ð97,4
 `;
         assert.strictEqual(
             detokenise(original),
-            `0REM1i0123456789!oOSCLI1234567890=^\\<>$o QWERTYUIOP@[_^v oOSCLIOSCLIASDFGHJKL:;]OSCLI )kOSCLIZXCVBNM,./OSCLI6g        q\`OSCLI!\`OSCLI!\`OSCLI~\`OSCLI aOSCLIOSCLI8f       q\`OSCLI!\`OSCLI!\`OSCLI~\`OSCLIsbOSCLIOSCLIOSCLI
+            `0REM1i0123456789!oÿ1234567890=^\\<>$o QWERTYUIOP@[_^v oÿÿASDFGHJKL:;]ÿ )kÿZXCVBNM,./ÿ6g        q\`ÿ!\`ÿ!\`ÿ~\`ÿ aÿÿ8f       q\`ÿ!\`ÿ!\`ÿ~\`ÿsbÿÿÿ
 1MODE1:Y=6:P=4420:!3320=RND:GCOL64,0:PLOT97,P,P:VDU535;P;P;P;P;5:GCOL16,0:MOVE80,50:PLOT97,1120,386:GCOL0,0:PLOT&65,80,500
-Q=PAGE+5:FORJ=0TO16:X=?Q-19:L=Q?1-96:Q=Q+2:FORI=0TOL:GCOL0,ATNP:MOVE10*X+64*I,60*Y:PLOT97,48,48:PLOT0,-40,0:GCOL0,3:IFPPLOT0,-8,0:VDU102:PLOT0,-12,-16
+Q=PAGE+5:FORJ=0TO16:X=?Q-19:L=Q?1-96:Q=Q+2:FORI=0TOL:GCOL0,ATNP:MOVE10*X+64*I,60*Y:PLOT97,48,48:PLOT0,-40,0:GCOL0,3:IFP PLOT0,-8,0:VDU102:PLOT0,-12,-16
 VDUQ?I:NEXT:Y=Y+(5ORY>1):Q=Q+L+1:P=0:NEXT:VDU1
 `
         );
+    });
+    it("should add spaces after tokens with the Conditional flag", () => {
+        assert.strictEqual(detokenise('\xf1\x9f\x841'), 'PRINTERR OR1');
+    });
+    it("should add spaces before tokens which follow an identifier", () => {
+        assert.strictEqual(detokenise('\xf1X\x84Y'), 'PRINTX ORY');
+    });
+    it("shouldn't expand tokens after DATA", () => {
+        assert.strictEqual(detokenise('\xDCX\x84Y'), 'DATAX\u0184Y');
     });
 });
 
@@ -96,5 +105,10 @@ describe("Partial detokenisation", () => {
         const rawProgram =
             '\x0d\x00\x0a\x14 \xf1 "Hello world"\x0d\x00\x0b\x0b \xe5 \x8d\x54\x4a\x40\x0d\xff';
         assert.strictEqual(partialDetokenise(rawProgram), '10 \xf1 "Hello world"\n11 \xe5 10');
+    });
+    it("should not result in invisible Unicode characters", () => {
+        const rawProgram =
+            '\x0d\x00\x0a\x08\xf1\x9f\x841\x0d\xff';
+        assert.strictEqual(partialDetokenise(rawProgram), '\xf1\u019f\u01841');
     });
 });


### PR DESCRIPTION
A space is added before expanding a token following an identifier.

A space is added after a token with the "Conditional" flag which is
followed by an alphanumeric, "_", or another token.

Tokens in REM statements are no longer expanded, as this breaks
peeking at binary data stashed in REM statements.

Tokens in DATA statements are no longer expanded, as they don't get
retokenised when the program is fed back to BASIC.

Non-expanded tokens which aren't printable Unicode characters are
now mapped to an equivalent printable Unicode character.  Fixes #23.
Also related to #42.