### PR TITLE
String variable fix

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -8,7 +8,7 @@ function escape(token) {
 function isExpressionToken(keyword) {
     // Does this token look like it'd be useful in an expression. Used to find sensible things to tokenise
     // in assembly statements (like LEN).
-    return (keyword.flags & ~Flags.Conditional) === 0 || keyword.keyword === 'FN';
+    return (keyword.flags & ~Flags.Conditional) === 0 || keyword.keyword === "FN";
 }
 
 const conditionalTokens = new Set(

--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -57,6 +57,17 @@ const invalidAbbreviatedTokensRegex = (() => {
         .join("|");
 })();
 
+const abbreviatedDollarTokensRegex = (() => {
+    // Find all abbreviated forms containing a "$".  It'll always be right before the "."
+    // because tokens with a "$" always end with either the "$" (and have no abbreviated
+    // form with it) or end with "$(".
+    const orRegex = keywords
+        .filter(kw => kw.keyword.endsWith("$("))
+        .map(kw => kw.keyword.slice(0, -2))
+        .join("|");
+    return "(" + orRegex + ")\\$.";
+})();
+
 export function registerBbcBasicLanguage() {
     languages.register({id: "BBCBASIC"});
 
@@ -97,8 +108,9 @@ export function registerBbcBasicLanguage() {
                 // This is slower than using the "tokens" built in to monarch but
                 // doesn't require whitespace delimited tokens.
                 [allTokensRegex, "keyword"],
+                [abbreviatedDollarTokensRegex, "keyword"],
                 [invalidAbbreviatedTokensRegex, "invalid"],
-                [/[A-Z$]+\./, {cases: {"@tokenPrefix": "keyword"}}],
+                [/[A-Z]+\./, {cases: {"@tokenPrefix": "keyword"}}],
                 [/^\s*\d+/, "enum"], // line numbers
                 {include: "@common"},
                 ["\\[", {token: "delimiter.square", next: "@asm"}],

--- a/test/bbcbasic_test.js
+++ b/test/bbcbasic_test.js
@@ -268,6 +268,28 @@ describe("Tokenisation", () => {
         // Surprisingly even abbreviations are affected by the continuation. See #36.
         checkTokens(["H.TO"], [{offset: 0, type: "invalid"}]);
     });
+    it("should not include $ mid token/identifier", () => {
+        checkTokens(
+            ["IFVALA$PRINTA$.1"],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 5, type: "variable"},
+                {offset: 7, type: "keyword"},
+                {offset: 12, type: "variable"},
+                {offset: 14, type: "number.float"},
+            ]
+        );
+    });
+    it("should parse floating point number after $", () => {
+        checkTokens(
+            ["P.$.114338E6"],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "operator"},
+                {offset: 3, type: "number.float"},
+            ]
+        );
+    });
 });
 
 function checkWarnings(text, ...expected) {


### PR DESCRIPTION
A related problem is that `PRINTA.1` is mishandled (owlet thinks it's token `PRINT` invalid token `A.` number `1` , but it's really token `PRINT`, variable `A`, number `.1`).

I'm struggling to see how to solve that while still highlighting bad tokens - I think maybe we need special handling after `PRINT` (which is also probably needed to flag errors for misuse of operator-like things that are only available in a few places, like `~`, `'` and `;`), and I think the fix here is a useful improvement by itself.