### PR TITLE
Highlight unterminated strings better

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -136,6 +136,10 @@ export function registerBbcBasicLanguage() {
                 [/[{}()]/, "@brackets"],
                 [/[a-zA-Z_][\w]*[$%]?/, "variable"],
                 // strings
+                [
+                    /["\u201c\u201d]([^"\u201c\u201d]|["\u201c\u201d]["\u201c\u201d])*$/,
+                    "invalid.string",
+                ],
                 [/["\u201c\u201d]/, {token: "string.quote", next: "@string"}],
                 // Unusual cases. We treat @% as a regular variable (see #28).
                 ["@%", "variable"],

--- a/test/bbcbasic_test.js
+++ b/test/bbcbasic_test.js
@@ -258,6 +258,29 @@ describe("Tokenisation", () => {
             ]
         );
     });
+    it("should handle an unterminated string gracefully", () => {
+        checkTokens(
+            ['P."', 'P."TEST', 'P."ESC""APE', 'P."OK"'],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "invalid.string"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "invalid.string"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "invalid.string"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "string.quote"},
+                {offset: 3, type: "string"},
+                {offset: 5, type: "string.quote"},
+            ]
+        );
+    });
     it("should tokenise continuation tokens when appropriate", () => {
         checkTokens(["TIME"], [{offset: 0, type: "keyword"}]);
         checkTokens(


### PR DESCRIPTION
Highlight an unterminated string as invalid - previously the
string was highlighted as a string, with the highlight carrying
over to the next line.