### PR TITLE
Fix handling of assembler comments

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -159,7 +159,7 @@ export function registerBbcBasicLanguage() {
                     "keyword",
                 ],
                 [/OPT|EQU[BDSW]/, "keyword.directive"],
-                [/[;\\][^:]*/, "comment"],
+                [/\\[^:]*/, "comment"],
                 [/,\s*[XY]/, "keyword"],
                 // labels
                 [/\.([a-zA-Z_][\w]*%?|@%)/, "type.identifier"],

--- a/test/bbcbasic_test.js
+++ b/test/bbcbasic_test.js
@@ -203,6 +203,32 @@ describe("Tokenisation", () => {
                 {offset: 6, type: "variable"},
             ]
         );
+        checkTokens(
+            ["[ROR 80\\comment:ROR80\\comment:]P."],
+            [
+                {offset: 0, type: "delimiter.square"},
+                {offset: 1, type: "keyword"},
+                {offset: 4, type: "white"},
+                {offset: 5, type: "number"},
+                {offset: 7, type: "comment"},
+                {offset: 15, type: "symbol"},
+                {offset: 16, type: "keyword"},
+                {offset: 19, type: "number"},
+                {offset: 21, type: "comment"},
+                {offset: 29, type: "symbol"},
+                {offset: 30, type: "delimiter.square"},
+                {offset: 31, type: "keyword"},
+            ]
+        );
+        // Regression test - `;` was incorrectly treated as a comment.
+        checkTokens(
+            ["[;notacomment"],
+            [
+                {offset: 0, type: "delimiter.square"},
+                {offset: 1, type: "operator"},
+                {offset: 2, type: "variable"},
+            ]
+        );
     });
     it("should notice REM statements", () => {
         checkTokens(


### PR DESCRIPTION
The BBC User Guide documents `\` as introducing a comment in the BBC
BASIC assembler.

Owlet previously incorrectly also recognised `;` as introducing a
comment.  I think there's a misunderstanding here because the assembler
seems to mostly ignore anything it isn't expecting after an instruction
until a `:` or the end of the line.  As a result of this, it may appear
that `;` is a comment character since you can write:

ROR A ; Anagram of ROAR

but you can equally write:

ROR A | Anagram of ROAR

or:

ROR A Anagram of ROAR

The acid test here is whether a comment works in place of an
instruction, e.g.

[\ comment

In this situation only `\` works, because only `\` really introduces
a comment.