### PR TITLE
Show BBC micro coordinates of mouse cursor

### DIFF
--- a/src/emulator.js
+++ b/src/emulator.js
@@ -307,19 +307,21 @@ export class Emulator {
       var x = event.offsetX;
       var y = event.offsetY;
       switch (screenMode) {
-      case 3:
-      w = 80; h = 25.6; break;
-      case 6:
-      w = 40; h = 25.6; break;
-      case 7:
-      w = 40; h = 25.6; break;
-      default:
-      // Graphics Y increases up the screen.
-      y = screen.height() - y;
-      w = 1280; h = 1024; break;
+        case 3:
+          w = 80; h = 25.6; break;
+        case 6:
+          w = 40; h = 25.6; break;
+        case 7:
+          w = 40; h = 25.6; break;
+        default:
+          // Graphics Y increases up the screen.
+          y = screen.height() - y;
+          w = 1280; h = 1024; break;
       }
-      x = Math.floor(x * w / screen.width());
-      y = Math.floor(y * h / screen.height());
+      // 8 and 16 here are fudges to allow for a margin around the screen
+      // canvas - not sure where that comes from...
+      x = Math.floor((x - 8) * w / (screen.width() - 16));
+      y = Math.floor((y - 8) * h / (screen.height() - 16));
       coords.innerHTML = `&nbsp;| (${x},${y})`;
     }
 

--- a/src/emulator.js
+++ b/src/emulator.js
@@ -74,6 +74,7 @@ export class Emulator {
     this.state = null;
     this.snapshot = new Snapshot();
     this.loop = (urlParams.get("loop")) ? true : false;
+    this.showCoords = false; // coordinate display mode
 
     window.theEmulator = this;
 
@@ -133,7 +134,7 @@ export class Emulator {
 
   timer() {
 
-    if (!beebjit_incoming) {
+    if (!beebjit_incoming && !this.showCoords) {
       this.emuStatus.innerHTML = `${modelName} | ${Math.floor(this.cpu.currentCycles/2000000)} s`;
     }
   }
@@ -293,14 +294,14 @@ export class Emulator {
     }
 
     mouseLeave() {
-      const coords = document.getElementById("coords");
-      coords.innerHTML = '';
+      this.showCoords = false;
+      this.timer();
     }
 
     mouseMove(event) {
+      this.showCoords = true;
       const processor = this.cpu;
       const screen = this.root.find(".screen");
-      const coords = document.getElementById("coords");
       var screenMode = processor.readmem(0x0355);
       var W;
       var H;
@@ -322,7 +323,6 @@ export class Emulator {
           W = 40; H = 25.6; graphicsMode = false; break;
         default:
           // Unknown screen mode!
-          coords.innerHTML = '';
           return;
       }
       // 8 and 16 here are fudges to allow for a margin around the screen
@@ -333,15 +333,15 @@ export class Emulator {
       const sh = screen.height() - 16;
       var X = Math.floor(x * W / sw);
       var Y = Math.floor(y * H / sh);
-      var html = `&nbsp;| text: (${X},${Y})`;
+      var html = `Text: (${X},${Y})`;
       if (graphicsMode) {
          // Graphics Y increases up the screen.
          y = sh - y;
          x = Math.floor(x * 1280 / sw);
          y = Math.floor(y * 1024 / sh);
-         html += ` graphics: (${x},${y})`;
+         html += ` &nbsp; Graphics: (${x},${y})`;
       }
-      coords.innerHTML = html;
+      this.emuStatus.innerHTML = html;
     }
 
     keyUp(event) {

--- a/src/emulator.js
+++ b/src/emulator.js
@@ -113,6 +113,8 @@ export class Emulator {
                     return this.executeInternalFast();
                   }
 
+    screen.mousemove(event => this.mouseMove(event));
+    screen.mouseleave(() => this.mouseLeave());
     screen.keyup(event => this.keyUp(event));
     screen.keydown(event => this.keyDown(event));
     screen.blur(() => this.clearKeys());
@@ -288,6 +290,37 @@ export class Emulator {
     clearKeys() {
       const processor = this.cpu;
       if (processor && processor.sysvia) processor.sysvia.clearKeys();
+    }
+
+    mouseLeave() {
+      const coords = document.getElementById("coords");
+      coords.innerHTML = '';
+    }
+
+    mouseMove(event) {
+      const processor = this.cpu;
+      const screen = this.root.find(".screen");
+      const coords = document.getElementById("coords");
+      var screenMode = processor.readmem(0x0355);
+      var w;
+      var h;
+      var x = event.offsetX;
+      var y = event.offsetY;
+      switch (screenMode) {
+      case 3:
+      w = 80; h = 25.6; break;
+      case 6:
+      w = 40; h = 25.6; break;
+      case 7:
+      w = 40; h = 25.6; break;
+      default:
+      // Graphics Y increases up the screen.
+      y = screen.height() - y;
+      w = 1280; h = 1024; break;
+      }
+      x = Math.floor(x * w / screen.width());
+      y = Math.floor(y * h / screen.height());
+      coords.innerHTML = `&nbsp;| (${x},${y})`;
     }
 
     keyUp(event) {

--- a/src/emulator.js
+++ b/src/emulator.js
@@ -302,27 +302,46 @@ export class Emulator {
       const screen = this.root.find(".screen");
       const coords = document.getElementById("coords");
       var screenMode = processor.readmem(0x0355);
-      var w;
-      var h;
-      var x = event.offsetX;
-      var y = event.offsetY;
+      var W;
+      var H;
+      var graphicsMode = true;
       switch (screenMode) {
+        case 0:
+          W = 80; H = 32; break;
+        case 1:
+        case 4:
+          W = 40; H = 32; break;
+        case 2:
+        case 5:
+          W = 20; H = 32; break;
         case 3:
-          w = 80; h = 25.6; break;
+          W = 80; H = 25.6; graphicsMode = false; break;
         case 6:
-          w = 40; h = 25.6; break;
+          W = 40; H = 25.6; graphicsMode = false; break;
         case 7:
-          w = 40; h = 25.6; break;
+          W = 40; H = 25.6; graphicsMode = false; break;
         default:
-          // Graphics Y increases up the screen.
-          y = screen.height() - y;
-          w = 1280; h = 1024; break;
+          // Unknown screen mode!
+          coords.innerHTML = '';
+          return;
       }
       // 8 and 16 here are fudges to allow for a margin around the screen
-      // canvas - not sure where that comes from...
-      x = Math.floor((x - 8) * w / (screen.width() - 16));
-      y = Math.floor((y - 8) * h / (screen.height() - 16));
-      coords.innerHTML = `&nbsp;| (${x},${y})`;
+      // canvas - not sure exactly where that comes from...
+      var x = event.offsetX - 8;
+      var y = event.offsetY - 8;
+      const sw = screen.width() - 16;
+      const sh = screen.height() - 16;
+      var X = Math.floor(x * W / sw);
+      var Y = Math.floor(y * H / sh);
+      var html = `&nbsp;| text: (${X},${Y})`;
+      if (graphicsMode) {
+         // Graphics Y increases up the screen.
+         y = sh - y;
+         x = Math.floor(x * 1280 / sw);
+         y = Math.floor(y * 1024 / sh);
+         html += ` graphics: (${x},${y})`;
+      }
+      coords.innerHTML = html;
     }
 
     keyUp(event) {

--- a/src/root.html
+++ b/src/root.html
@@ -63,6 +63,7 @@
         <button class="save" data-action="save" title="Save memory from the emulator">save</button>
         <button data-action="rocket" id="rocket" title="send to beebjit">🚀</button>
         <div id="emu_status"></div>
+        <div id="coords"></div>
     </div>
     <div class="kudos"><a href="#" id="like"></a></div>
     <div id="mobile">


### PR DESCRIPTION
Handy when you want to know the coordinates to enter into your BASIC program to plot something at a particular position.

This pretty much works, but there seems to be some padding inside the "screen" canvas which I'm not sure how to correctly allow for so the coordinates are a little bit off (worse towards the lower left).

In text modes the coordinates are text coordinates.  Maybe we should show text and graphics coordinates in graphics modes.