### PR TITLE
Update for Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Owlet Editor🦉 ![Owlet CI and CD](https://github.com/mattgodbolt/owlet-editor/workflows/Owlet%20CI%20and%20CD/badge.svg)
-A simple, intuitive creative coding tool for BBC BASIC inspired by [BBC Micro Bot](https://www.twitter.com/bbcmicrobot)
+A simple, intuitive creative coding tool for BBC BASIC inspired by [BBC Micro Bot](https://mastodon.me.uk/@bbcmicrobot)
 
 
 Try the beta now at [bbcmic.ro](https://bbcmic.ro) and get coding!
@@ -16,10 +16,10 @@ Try the beta now at [bbcmic.ro](https://bbcmic.ro) and get coding!
 * Share your entire program as a URL
 * Export to external emulator for interactive use
 
-## Share your creations with the BBC Micro Bot Twitter community
+## Share your creations with the BBC Micro Bot Mastodon community
 
-* One button tweet to share code
-* Automatic code golfing tools - byte token and base2048 encode/decode
+* One button tweet to share code (not yet updated for Mastodon)
+* Automatic code golfing tools - byte token encode/decode
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,9 @@ function programUrl(id) {
 
 function updateUiForProgram(id, json) {
     $("#like")
-        .html(`<span class="heart">♥</span>code originally posted by ${json.author} on Twitter`)
-        .attr("href", `https://twitter.com/intent/like?tweet_id=${id}`);
+        .html(`<span class="heart">♥</span>code originally posted by ${json.author} on Twitter`);
+    // FIXME Update for Mastodon
+    // .attr("href", `https://twitter.com/intent/like?tweet_id=${id}`);
 }
 
 window.u = updateUiForProgram;

--- a/src/owlet.js
+++ b/src/owlet.js
@@ -17,7 +17,7 @@ import ResizeObserver from "resize-observer-polyfill";
 import {makeUEF} from "./UEF";
 import {AcornDFSdisc} from "./DFS";
 
-const TweetMaximum = 280;
+const TweetMaximum = 500;
 const StateVersion = 1;
 
 function defaultLineNumber(line) {
@@ -241,12 +241,6 @@ export class OwletEditor {
     updateStatus(basicText) {
         let outputProgram = basicText;
         let format = "text";
-
-        if (outputProgram.length > TweetMaximum) {
-            outputProgram = encode(outputProgram.split("").map(c => c.charCodeAt(0)));
-            format = "base2048";
-        }
-
         this.editStatus
             .find(".count")
             .text(`${outputProgram.length} ${format}`)
@@ -424,10 +418,12 @@ export class OwletEditor {
                 this.closeModal();
             },
             tweet: () => {
+                /* FIXME Automate posting to Mastodon?
                 window.open(
                     `https://twitter.com/intent/tweet?screen_name=BBCmicrobot&text=${this.codeToTweet()}`,
                     "_new"
                 );
+                */
                 this.closeModal();
             },
             copyMem: () => {

--- a/src/root.html
+++ b/src/root.html
@@ -21,19 +21,21 @@
             <h3>Owlet Editor - beta</h3>
             <p>A simple, modern editor for retro coding in BBC BASIC (1981) inspired by <a
                     href="https://www.bbcmicrobot.com">BBC Micro bot</a></p>
-            <p>Created by <a href="https://twitter.com/dominicpajak">Dominic Pajak</a> and
+            <p>Created by <a href="https://mastodon.me.uk/@Dominic">Dominic Pajak</a> and
                 <a href="https://twitter.com/mattgodbolt">Matt Godbolt</a>.
                 Contribute source and submit issues on <a href="https://github.com/mattgodbolt/owlet-editor">GitHub</a>.
             </p>
             <p>With thanks to the Bitshifters Collective, Kweepa, P_Malin, Rheolism, and the whole BBC Micro bot
                 community.
             <p>
+            <!-- FIXME Update for Mastodon
             <p>&nbsp;</p>
             <p>
                 <a class="twitter-follow-button" data-show-count="false"
                    href="https://twitter.com/BBCmicroBot?ref_src=twsrc%5Etfw">Follow @BBCmicroBot</a>
                 <script async charset="utf-8" src="https://platform.twitter.com/widgets.js"></script>
             </p>
+            -->
         </div>
         <div id="examples">
             <div class="template example" style="cursor: pointer;">
@@ -68,19 +70,21 @@
         <h3>About the Owlet BBC BASIC editor</h3>
         <p>Owlet is a simple, modern editor for retro coding in BBC BASIC (1981) inspired by <a
                 href="https://www.bbcmicrobot.com">BBC Micro bot</a></p>
-        <p>Created by <a href="https://twitter.com/dominicpajak">Dominic Pajak</a> and
+        <p>Created by <a href="https://mastodon.me.uk/@Dominic">Dominic Pajak</a> and
             <a href="https://twitter.com/mattgodbolt">Matt Godbolt</a> based on the <a href="https://bbc.godbolt.org">JSBeeb</a> emulator and Monaco editor.
             Contribute source and submit issues on <a href="https://github.com/mattgodbolt/owlet-editor">GitHub</a>.
         </p>
         <p>With thanks to the Bitshifters Collective, Kweepa, P_Malin, Rheolism, and the whole BBC Micro bot
             community.
         <p>
+        <!-- FIXME Update for Mastodon
         <p>&nbsp;</p>
         <p>
             <a class="twitter-follow-button" data-show-count="false"
                href="https://twitter.com/BBCmicroBot?ref_src=twsrc%5Etfw">Follow @BBCmicroBot</a>
             <script async charset="utf-8" src="https://platform.twitter.com/widgets.js"></script>
         </p>
+        -->
     </div>
 </div>
 
@@ -89,7 +93,7 @@
     <div class="modal-content">
         <p><b>Share your BBC Micro program</b></p>
         <p id="share-content">The web link below contains a copy of the current program. You can save it, share it or
-            tweet it to bbcmicrobot.</p>
+            tweet it to bbcmicrobot (tweet button inactive, needs update for Mastodon).</p>
         <input id="copyText" type="text" value="Hello World">
         <button data-action="copy">Copy as URL</button>
         <button data-action="cassette">Tape</button>

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -4,14 +4,8 @@ import {decode} from "base2048";
 
  BBC BASIC Keyword Byte Tokens
 
- Derived from twitter.com/rheolism
+ Derived from rheolism's
  https://github.com/8bitkick/BBCMicroBot/blob/master/tools/bbcbasictokenise
-
- To twitter these inclusive ranges count as 1 character (everything else as 2):
- U+0000-U+10FF
- U+2000-U+200D # various spaces
- U+2010-U+201F # various punctuation
- U+2032-U+2037 # various prime marks
 
  Array starts at byte token 0x80
 
@@ -426,7 +420,14 @@ function decode2048(input) {
 
 
 // Compatibility with pre-tokenizer keyboard buffer method
-// See https://twitter.com/bbcmicrobot/status/1329217276860538881?s=20
+//
+// Only some token values make it through.
+//
+// It seems that U+00D0-U+00DA, U+00E0-U+00EA, U+00F0-U+00FA work;
+// U+0090-U+009A. U+00A0-U+00AA map to a byte value 16 lower (so U+0090 -> AND
+// which has byte token &80).
+//
+// The bot discards higher bits, so e.g. U+0190 -> AND too. All ranges incl.
 export function backwardCompat(text) {
     let output = "";
     const codePoints = [...text].map(char => char.charCodeAt(0));


### PR DESCRIPTION
Disable the tweet button for now.  The bot is no longer accepting programs on twitter.  Needs hooking up for mastodon ideally, but that's more complicated due to the federated aspect, and may not be possible at all.  If not we can probably provide a "copy toot to clipboard" or something like that.

Update links to the Bot and Dom's profiles.  It seems Matt doesn't have one yet so I've left that be.

Increase the length limit to 500 characters to match Mastodon (though it's not quite that simple as you need a #bbcmicrobot hashtag too; that sort of existed before as you needed @bbcmicrobot except you could avoid that by posting as a reply to the bot).

Drop the base2048 encoding bits as the bot no longer supports that.

Inline tokenisation details rather than linking to an old rheolism tweet in case twitter dies completely or starts purging old messages to reduce costs.