### PR TITLE
Fix more cases of *-command highlighting

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -29,6 +29,10 @@ const allTokensForAsmRegex = keywords
     .map(escape)
     .join("|");
 
+const allByteTokensRegex = "[" + keywords
+    .map(kw => String.fromCodePoint(kw.token < 160 ? kw.token + 0x100 : kw.token))
+    .join("") + "]";
+
 function allAbbreviations(tokens) {
     const prefixes = new Set();
     for (const token of tokens) {
@@ -116,10 +120,11 @@ export function registerBbcBasicLanguage() {
                 [/(\bREM|\xf4)$/, {token: "keyword"}], // A REM on its own line
                 [/(\bREM|\xf4)/, {token: "keyword", next: "@remStatement"}], // A REM consumes to EOL
                 [/(FN|PROC|\xa4|\xf2)/, {token: "keyword", next: "@fnProcName"}],
-                [/THEN|ELSE|\u018c|\u018b/, "keyword", "@pop"], // ELSE or THEN end a statement
+                [/THEN|THE\.|TH\.|ELSE|ELS\.|EL\.|ERROR|ERRO\.|ERR\.|\u018c|\u018b|\u0185/, "keyword", "@pop"], // THEN, ELSE, ERROR end a statement
                 // This is slower than using the "tokens" built in to monarch but
                 // doesn't require whitespace delimited tokens.
                 [allTokensRegex, "keyword"],
+                [allByteTokensRegex, "keyword"],
                 [abbreviatedDollarTokensRegex, "keyword"],
                 [invalidAbbreviatedTokensRegex, "invalid"],
                 [/[A-Z]+\./, {cases: {"@tokenPrefix": "keyword"}}],

--- a/test/bbcbasic_test.js
+++ b/test/bbcbasic_test.js
@@ -390,7 +390,20 @@ describe("Tokenisation", () => {
     });
     it("should handle OSCLI after THEN and ELSE", () => {
         checkTokens(
-            ["IF1THEN*HIMEM", "IF0ELSE*HIMEM"],
+            [
+                "IF1THEN*H.",
+                "IF1THE.*H.",
+                "IF1TH.*H.",
+                "\xe71\u018c*H.",
+                "IF0ELSE*H.",
+                "IF0ELS.*H.",
+                "IF0EL.*H.",
+                "\xe70\u018b*H.",
+                "ONERROR*H.",
+                "ONERRO.*H.",
+                "ONERR.*H.",
+                "\xee\u0185*H.",
+            ],
             [
                 {offset: 0, type: "keyword"},
                 {offset: 2, type: "number"},
@@ -402,6 +415,58 @@ describe("Tokenisation", () => {
                 {offset: 2, type: "number"},
                 {offset: 3, type: "keyword"},
                 {offset: 7, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "number"},
+                {offset: 3, type: "keyword"},
+                {offset: 6, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 1, type: "number"},
+                {offset: 2, type: "keyword"},
+                {offset: 3, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "number"},
+                {offset: 3, type: "keyword"},
+                {offset: 7, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "number"},
+                {offset: 3, type: "keyword"},
+                {offset: 7, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "number"},
+                {offset: 3, type: "keyword"},
+                {offset: 6, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 1, type: "number"},
+                {offset: 2, type: "keyword"},
+                {offset: 3, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 7, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 7, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 6, type: "keyword.oscli"},
+            ],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 2, type: "keyword.oscli"},
             ],
         );
     });


### PR DESCRIPTION
Handle abbreviated `THEN` and `ELSE`.

Handle *-command after `ON ERROR`.

Syntax highlight all tokenised keywords, not just ones we have special handling for.

Test tokenised versions.

See #112