### PR TITLE
Hook up sound from jsbeeb

### DIFF
--- a/src/root.html
+++ b/src/root.html
@@ -6,6 +6,9 @@
     </div>
  
     <div>
+        <div id="audio-warning" class="alert alert-warning initially-hidden">
+            Your browser has suspended audio -- mouse click or key press for sound.
+        </div>
     </div>
     <div class="toolbar" id="emu_toolbar">
         <button data-action="run" title="Run the program (ctrl-enter)"><i class="fa-solid fa-play" style="pointer-events: none;"></i></button>


### PR DESCRIPTION
This patch does get us working sound, but during loading a modal full-window error pops up:

Uncaught runtime errors:
ERROR
The operation was aborted.

Clicking the X in the top right continues to a working owlet.  I've failed to work out where this is coming from.

Fixes #80