### PR TITLE
Drop invalid blockComment setting

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -220,7 +220,6 @@ export function registerBbcBasicLanguage() {
 
     languages.setLanguageConfiguration("BBCBASIC", {
         comments: {
-            blockComment: ["REM", ":"],
             lineComment: "REM",
         },
         brackets: [


### PR DESCRIPTION
There isn't a block comment in BBC BASIC, but we were setting `REM` ... `:` as one.  The result was that the editor's "Toggle block comment" command would insert a REM before the selection and ":" after which doesn't actually comment out the selected block.

If we don't set this, the block comment commands just don't do anything, which seems more helpful than doing something wrong.