### PR TITLE
Remove braces from symbols

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -105,7 +105,7 @@ export function registerBbcBasicLanguage() {
             "'",
         ],
         tokenPrefix: allAbbreviations(keywords.map(kw => kw.keyword)),
-        symbols: /[-+#=><!*/{}:?$;,~^']+/,
+        symbols: /[-+#=><!*/:?$;,~^']+/,
         tokenizer: {
             root: [
                 {include: "@whitespace"},
@@ -159,7 +159,7 @@ export function registerBbcBasicLanguage() {
                 [/\d+E[-+]?\d+/, "number.float"],
                 [/\d+/, "number"],
                 [/&[0-9A-F]+/, "number.hex"],
-                [/[{}()]/, "@brackets"],
+                [/[()]/, "@brackets"],
                 [/[a-zA-Z_][\w]*[$%]?/, "variable"],
                 // strings
                 [

--- a/test/bbcbasic_test.js
+++ b/test/bbcbasic_test.js
@@ -275,6 +275,20 @@ describe("Tokenisation", () => {
         checkTokens(["^"], [{offset: 0, type: "operator"}]);
         checkTokens(["'"], [{offset: 0, type: "operator"}]);
     });
+    it("should correctly handle invalid symbols", () => {
+        checkTokens(
+            ["DEFFNmain:{=0}"],
+            [
+                {offset: 0, type: "keyword"},
+                {offset: 5, type: "variable"},
+                {offset: 9, type: "symbol"},
+                {offset: 10, type: "invalid"},
+                {offset: 11, type: "operator"},
+                {offset: 12, type: "number"},
+                {offset: 13, type: "invalid"},
+            ]
+        );
+    });
     it("should not treat C specially after a string", () => {
         checkTokens(
             ['P.""C1'],


### PR DESCRIPTION
Braces are not valid symbols in BBC BASIC.