### PR TITLE
Remove unneeded REM rule

### DIFF
--- a/src/bbcbasic.js
+++ b/src/bbcbasic.js
@@ -116,7 +116,6 @@ export function registerBbcBasicLanguage() {
             statement: [
                 ["\n", "", "@pop"],
                 [":", "symbol", "@pop"],
-                [/(\bREM|\xf4)$/, {token: "keyword"}], // A REM on its own line
                 [/(\bREM|\xf4)/, {token: "keyword", next: "@remStatement"}], // A REM consumes to EOL
                 [/(FN|PROC|\xa4|\xf2)/, {token: "keyword", next: "@fnProcName"}],
                 [


### PR DESCRIPTION
We don't need a special rule for an empty REM as remStatement can be empty.

Note we already have test coverage for this case.